### PR TITLE
Better support to layer event propagation

### DIFF
--- a/libs/mapjet-core/src/index.ts
+++ b/libs/mapjet-core/src/index.ts
@@ -7,3 +7,4 @@ export * from './lib/utils/models';
 export * from './lib/controller';
 export * from './lib/utils-test/mapjet.mock';
 export * from './lib/utils-test/svg.mock';
+export { LayerEvent } from './lib/utils/layer-event-handler';

--- a/libs/mapjet-core/src/lib/utils/layer-event-handler.ts
+++ b/libs/mapjet-core/src/lib/utils/layer-event-handler.ts
@@ -60,10 +60,7 @@ export class LayerEventHandler {
     // This makes a sorted array of the layers that are clicked
     var sortedLayers = eventFeatures.reduce((sorted: any[], next) => {
       let nextLayerId = next.layer.id;
-      if (sorted.indexOf(nextLayerId) === -1) {
-        return sorted.concat([nextLayerId]);
-      }
-      return sorted;
+      return sorted.indexOf(nextLayerId) === -1 ? sorted.concat([nextLayerId]) : sorted;
     }, []);
 
     // Add the layers and features info to the event

--- a/libs/mapjet-core/src/lib/utils/layer-event-handler.ts
+++ b/libs/mapjet-core/src/lib/utils/layer-event-handler.ts
@@ -1,5 +1,12 @@
 import { Map, MapEvent } from 'maplibre-gl';
 
+export type LayerEvent<T> = {
+  cancelBubble: boolean;
+  cancelImmediate: boolean;
+  stopPropagation(): void;
+  stopImmediatePropagation(): void;
+} & T;
+
 // Code example: https://github.com/mapbox/mapbox-gl-js/issues/5783#issuecomment-394856120
 export class LayerEventHandler {
   private readonly map: Map;
@@ -15,7 +22,7 @@ export class LayerEventHandler {
     this._onMapEvent = this._onMapEvent.bind(this);
   }
 
-  public on(eventName: MapEvent, layerId: string, callback: () => any): void {
+  public on(eventName: MapEvent, layerId: string | null, callback: (...args: any[]) => any): void {
     if (!this.defaultHandlers[eventName] && !this.handlers[eventName]) {
       // Create new event name keys in our storage maps
       this.defaultHandlers[eventName] = [];
@@ -30,14 +37,15 @@ export class LayerEventHandler {
       this.defaultHandlers[eventName].push(callback);
     } else {
       // layerId is specified, so this is a specific handler for that layer
-      this.handlers[eventName][layerId] = callback;
+      this.handlers[eventName][layerId] = [...(this.handlers[eventName][layerId] || []), callback];
     }
   }
 
-  public off(eventName: MapEvent, layerId: string): void {
-    if (this.handlers[eventName] && this.handlers[eventName][layerId]) {
-      this.handlers[eventName][layerId] = null;
-      delete this.handlers[eventName][layerId];
+  public off(eventName: MapEvent, layerId: string | null, callbackRef: (...args: any[]) => any): void {
+    if (layerId && this.handlers[eventName] && this.handlers[eventName][layerId]) {
+      this.handlers[eventName][layerId] = this.handlers[eventName][layerId].filter(cb => cb !== callbackRef);
+    } else if (!layerId && this.defaultHandlers[eventName]) {
+      this.defaultHandlers[eventName] = this.defaultHandlers[eventName].filter(cb => cb !== callbackRef);
     }
   }
 
@@ -61,6 +69,16 @@ export class LayerEventHandler {
     // Add the layers and features info to the event
     event.eventLayers = sortedLayers;
     event.eventFeatures = eventFeatures;
+    event.cancelBubble = false;
+    event.cancelImmediate = false;
+
+    event.stopPropagation = function () {
+      this.cancelBubble = true;
+    };
+
+    event.stopImmediatePropagation = function () {
+      this.cancelImmediate = true;
+    };
 
     let bubbleEvent = true;
 
@@ -77,7 +95,15 @@ export class LayerEventHandler {
       });
 
       // Call the layer handler for this layer, giving the clicked features
-      bubbleEvent = this.handlers[eventName][layerId](event, layerFeatures);
+      for (const callback of this.handlers[eventName][layerId]) {
+        callback(event, layerFeatures);
+
+        bubbleEvent = !event.cancelBubble;
+
+        if (event.cancelImmediate) {
+          break;
+        }
+      }
     }
 
     if (bubbleEvent === true) {
@@ -86,9 +112,15 @@ export class LayerEventHandler {
         return;
       }
 
-      this.defaultHandlers[eventName].forEach(handler => {
+      for (const handler of this.defaultHandlers[eventName]) {
         handler(event);
-      });
+
+        bubbleEvent = !event.cancelBubble;
+
+        if (!event.cancelImmediate) {
+          break;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Postanowiłem trochę ulepszyć ten mechanizm propagacji eventów. W poprzedniej wersji nie dało się zapiąć kilka event handlerów na ten sam event w danej warstwie. Poprzednie rozwiązanie nie obsługiwało również wyrejestrowania event handlera na wszystkich warstwach(bug). 

Dorobiłem metody `stopPropagation` oraz `stopImmediatePropagation` na evencie - co jest bardziej elastyczne w użyciu. Będzie można  teraz tego w taki sposób:
```js
mapCore.layerEventHandler.on('contextmenu', 'points', (e: LayerEvent<MapMouseEvent>) => {
   e.stopPropagation(); 
   console.log('layer 1'); // To się wykona
});
mapCore.layerEventHandler.on('contextmenu', 'background', (e: LayerEvent<MapMouseEvent>) => {
   console.log('background'); // To się nie wykona
});
mapCore.layerEventHandler.on('contextmenu', 'points', (e: LayerEvent<MapMouseEvent>) => {
   e.stopImmediatePropagation();
   console.log('layer 1'); // To się wykona
});
mapCore.layerEventHandler.on('contextmenu', 'points', (e: LayerEvent<MapMouseEvent>) => {
   console.log('layer 1'); // To się nie wykona
});
```

Dodatkowo zrobiłem generyczny typ tego nowego eventu.