### PR TITLE
typed and safe dispatcher

### DIFF
--- a/libs/mapjet-core/src/lib/utils/dispatcher.ts
+++ b/libs/mapjet-core/src/lib/utils/dispatcher.ts
@@ -1,15 +1,27 @@
-export class Dispatcher {
-  private callbacks = {};
+export class Dispatcher<EventMap extends object> {
+  private callbacks: { [key in keyof EventMap]?: Array<(...args) => void> } = {};
 
-  public fire(event, data) {
-    (this.callbacks[event] || []).forEach(callback => callback(data));
+  public fire<E extends keyof EventMap> (event:  E, data: EventMap[E]) {
+    this.getEventCallbacks(event).forEach((callback) => {
+      try {
+        callback(data);
+      } catch (e) {
+        console.error(e);
+      }
+    });
   }
 
-  public on(event, callback) {
-    this.callbacks[event] = [...(this.callbacks[event] || []), callback];
+  public on<E extends keyof EventMap>(event: E, callback: (event: EventMap[E]) => void): void {
+    this.callbacks[event] = [...this.getEventCallbacks(event), callback];
   }
 
-  public off(event, callback) {
-    this.callbacks[event] = (this.callbacks[event] || []).filter(c => c !== callback);
+  public off<E extends keyof EventMap>(event: E, callback: (event: EventMap[E]) => void) {
+    this.callbacks[event] = this.getEventCallbacks(event).filter(
+      (c) => c !== callback
+    );
+  }
+
+  private getEventCallbacks<E extends keyof EventMap>(event: E): Array<(...args) => void> {
+    return this.callbacks[event] || [];
   }
 }


### PR DESCRIPTION
Te zmiany pozwalają na bardziej definitywne typowanie eventów. Można teraz będzie typować w parze nazwę eventu i zwracany typ eventu. 

np.

```
interface FooPluginEventsMap {
  click: ClickEvent;
  close: CloseEvent;
}

const dis = new Dispatcher<FooPluginEventsMap>();

dis.on('click', console.log) // ClickEvent {}
```

Dodatkowo dodałem operator try/catch do wywołania callbacka. Callbacki nie powinny powodować zacięcia się programu. 